### PR TITLE
Allow Ternary in no-unused-expressions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -153,7 +153,9 @@ module.exports = {
         "no-underscore-dangle": ["error", { "allow": ["_links", "_embedded"] }],
         "no-unneeded-ternary": ["error"],
         "no-unreachable": ["error"],
-        "no-unused-expressions": ["error"],
+        "no-unused-expressions": ["error", {
+            "allowTernary": true
+        }],
         "no-unused-vars": ["error", {
             "vars": "all",
             "args": "after-used"


### PR DESCRIPTION
[documentation](https://eslint.org/docs/2.0.0/rules/no-unused-expressions)