### PR TITLE
Release 2.2.0-alpha

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-cimpress-atsquad",
-  "version": "2.1.5",
+  "version": "2.2.0-alpha",
   "description": "ESLint config from the Cimpress AT Squad",
   "main": "eslint.js",
   "author": "Cimpress AT Squad <atsquad@cimpress.com>",
@@ -10,17 +10,17 @@
     "url": "git+https://github.com/Cimpress-MCP/eslint-config-cimpress-atsquad.git"
   },
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "3.3.0",
-    "@typescript-eslint/parser": "3.3.0",
-    "eslint-config-airbnb-typescript": "8.0.2",
-    "eslint-config-prettier": "6.11.0",
-    "eslint-plugin-import": "2.22.1",
+    "@typescript-eslint/eslint-plugin": "5.9.1",
+    "@typescript-eslint/parser": "5.9.1",
+    "eslint-config-airbnb-typescript": "16.1.0",
+    "eslint-config-prettier": "8.3.0",
+    "eslint-plugin-import": "2.25.4",
     "eslint-plugin-jest": "23.13.2",
-    "eslint-plugin-prettier": "3.1.4",
-    "eslint-plugin-unicorn": "20.1.0"
+    "eslint-plugin-prettier": "4.0.0",
+    "eslint-plugin-unicorn": "40.0.0"
   },
   "peerDependencies": {
-    "eslint": ">=7.2.0",
-    "prettier": ">=2.0.5"
+    "eslint": ">=8.6.0",
+    "prettier": ">=2.5.1"
   }
 }


### PR DESCRIPTION
Upgrade packages and peerDependencies

Going to release this because I cannot figure out how to test it with `yarn link`. The plugins (like unicorn) have compatibility code that should work with eslint 8.x.x breaking changes (https://eslint.org/docs/8.0.0/user-guide/migrating-to-8.0.0#the-lib-entrypoint-has-been-removed) but they don't when using `yarn link`.

Trying to version it as alpha so that we can make 2.2.0 the final release.